### PR TITLE
feat: add `htmx` and `hyperscript`

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -282,4 +282,17 @@ export const allDevtools = {
       })
     },
   },
+  ['htmx.org']: {
+    packageName: true,
+    enable: () => {
+      defineWindowProperty('htmx', {
+        version: VersionMap['htmx.org'],
+      })
+    },
+  },
+  hyperscript: {
+    enable: () => {
+      defineWindowProperty('_hyperscript', {})
+    }
+  }
 } satisfies { [key: string]: Config }

--- a/src/version.json
+++ b/src/version.json
@@ -1,11 +1,12 @@
 {
-  "sentry": "0.1.2",
-  "codemirror": "6.0.1",
-  "vuepress": "1.9.10",
   "prism": "4.1.2",
-  "antd": "5.10.3",
+  "sentry": "0.1.2",
   "gsap": "3.12.2",
   "rive": "1.1.4",
+  "codemirror": "6.0.1",
+  "antd": "5.11.0",
   "three": "0.158.0",
+  "vuepress": "1.9.10",
+  "htmx.org": "1.9.7",
   "next": "14.0.1"
 }


### PR DESCRIPTION
Add support for `htmx` and `hyperscript`:

- `hyperscript`:
  - `hyperscript` on wappalyzer: https://www.wappalyzer.com/technologies/javascript-libraries/hyperscript/
  - `hyperscript` detection: https://github.com/dochne/wappalyzer/blob/471c2fb0b093973c098bd1855b89c8cde4997479/src/technologies/_.json#L210
- `htmx`
  - `htmx` on wappalyzer: https://www.wappalyzer.com/technologies/javascript-libraries/htmx/
  - `htmx` detection: https://github.com/dochne/wappalyzer/blob/471c2fb0b093973c098bd1855b89c8cde4997479/src/technologies/h.json#L1327 